### PR TITLE
use generic integer type to store bits internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 bitstream-io = "1.2.0"
-num-traits = "0.2.14"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/src/bitstore.rs
+++ b/src/bitstore.rs
@@ -23,22 +23,37 @@ pub trait BitStore:
 
     /// the multiplicative identity
     const ONE: Self;
+
+    /// integer natural logarithm, rounded down
+    fn log2(self) -> u32;
 }
 
 impl BitStore for u32 {
     const BITS: u32 = u32::BITS;
     const ONE: Self = 1;
     const ZERO: Self = 0;
+
+    fn log2(self) -> u32 {
+        u32::log2(self)
+    }
 }
 
 impl BitStore for u64 {
     const BITS: u32 = u64::BITS as u32;
     const ONE: Self = 1;
     const ZERO: Self = 0;
+
+    fn log2(self) -> u32 {
+        u64::log2(self)
+    }
 }
 
 impl BitStore for u128 {
     const BITS: u32 = u128::BITS as u32;
     const ONE: Self = 1;
     const ZERO: Self = 0;
+
+    fn log2(self) -> u32 {
+        u128::log2(self)
+    }
 }

--- a/src/bitstore.rs
+++ b/src/bitstore.rs
@@ -1,0 +1,32 @@
+use std::ops::{Add, AddAssign, Div, Mul, Shl, ShlAssign, Sub};
+
+/// A trait for a type that can be used for the internal integer representation
+/// of an encoder or decoder
+pub trait BitStore:
+    Shl<u32, Output = Self>
+    + ShlAssign<u32>
+    + Sized
+    + From<u32>
+    + Sub<Output = Self>
+    + Add<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + AddAssign
+    + PartialOrd
+    + Copy
+{
+    /// the number of bits needed to represent this type
+    const BITS: u32;
+
+    /// the additive identity
+    const ZERO: Self;
+
+    /// the multiplicative identity
+    const ONE: Self;
+}
+
+impl BitStore for u32 {
+    const BITS: u32 = u32::BITS;
+    const ONE: Self = 1_u32;
+    const ZERO: Self = 0_u32;
+}

--- a/src/bitstore.rs
+++ b/src/bitstore.rs
@@ -27,6 +27,18 @@ pub trait BitStore:
 
 impl BitStore for u32 {
     const BITS: u32 = u32::BITS;
-    const ONE: Self = 1_u32;
-    const ZERO: Self = 0_u32;
+    const ONE: Self = 1;
+    const ZERO: Self = 0;
+}
+
+impl BitStore for u64 {
+    const BITS: u32 = u64::BITS as u32;
+    const ONE: Self = 1;
+    const ZERO: Self = 0;
+}
+
+impl BitStore for u128 {
+    const BITS: u32 = u128::BITS as u32;
+    const ONE: Self = 1;
+    const ZERO: Self = 0;
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bitstream_io::BitRead;
 
-use crate::{BitStore, Error, Model};
+use crate::{util, BitStore, Error, Model};
 
 // this algorithm is derived from this article - https://marknelson.us/posts/2014/10/19/data-compression-with-arithmetic-coding.html
 
@@ -11,18 +11,17 @@ use crate::{BitStore, Error, Model};
 /// An arithmetic decoder converts a stream of bytes into a stream of some
 /// output symbol, using a predictive [`Model`].
 #[derive(Debug)]
-pub struct Decoder<M, R, B = u32>
+pub struct Decoder<M, R>
 where
-    B: BitStore,
     M: Model,
     R: BitRead,
 {
     model: M,
     precision: u32,
-    low: B,
-    high: B,
+    low: M::B,
+    high: M::B,
     input: R,
-    x: B,
+    x: M::B,
 }
 
 trait BitReadExt {
@@ -39,11 +38,10 @@ impl<R: BitRead> BitReadExt for R {
     }
 }
 
-impl<M, R, B> Decoder<M, R, B>
+impl<M, R> Decoder<M, R>
 where
     M: Model,
     R: BitRead,
-    B: BitStore,
 {
     /// Construct a new [`Decoder`]
     ///
@@ -67,18 +65,11 @@ where
     /// If these constraints cannot be satisfied this method will panic in debug
     /// builds
     pub fn new(model: M, input: R) -> io::Result<Self> {
-        let frequency_bits = model.max_denominator().log2() + 1;
-        let minimum_precision = frequency_bits + 2;
-        debug_assert!(
-            (frequency_bits + minimum_precision) <= u32::BITS,
-            "not enough bits to guarantee overflow/underflow avoidance"
-        );
-        let precision = u32::BITS - frequency_bits;
+        let precision = util::precision(model.max_denominator());
 
-        let low = B::ZERO;
-        let high = B::ONE << precision;
-
-        let x = B::ZERO;
+        let low = M::B::ZERO;
+        let high = M::B::ONE << precision;
+        let x = M::B::ZERO;
 
         let mut encoder = Self {
             model,
@@ -95,19 +86,27 @@ where
 
     fn fill(&mut self) -> io::Result<()> {
         for _ in 0..self.precision {
-            let bit = self.input.next_bit()?.unwrap_or_default();
             self.x <<= 1;
-            self.x += u32::from(bit);
+            match self.input.next_bit()? {
+                Some(true) => {
+                    self.x += M::B::ONE;
+                }
+                Some(false) | None => (),
+            }
         }
         Ok(())
     }
 
-    const fn half(&self) -> u32 {
-        1 << (self.precision - 1)
+    fn half(&self) -> M::B {
+        M::B::ONE << (self.precision - 1)
     }
 
-    const fn quarter(&self) -> u32 {
-        1 << (self.precision - 2)
+    fn quarter(&self) -> M::B {
+        M::B::ONE << (self.precision - 2)
+    }
+
+    fn three_quarter(&self) -> M::B {
+        self.half() + self.quarter()
     }
 
     /// Read the next symbol from the stream of bits
@@ -118,9 +117,9 @@ where
     ///
     /// This method can fail if the underlying [`BitRead`] cannot be read from.
     pub fn decode_symbol(&mut self) -> Result<Option<M::Symbol>, Error<M::ValueError>> {
-        let range = self.high - self.low + B::ONE;
+        let range = self.high - self.low + M::B::ONE;
         let value =
-            ((self.x - self.low + B::ONE) * B::from(self.model.denominator()) - B::ONE) / range;
+            ((self.x - self.low + M::B::ONE) * self.model.denominator() - M::B::ONE) / range;
         let symbol = self.model.symbol(value);
 
         let p = self
@@ -128,7 +127,7 @@ where
             .probability(symbol.as_ref())
             .map_err(Error::ValueError)?;
 
-        self.high = self.low + (range * p.end) / self.model.denominator() - 1;
+        self.high = self.low + (range * p.end) / self.model.denominator() - M::B::ONE;
         self.low += (range * p.start) / self.model.denominator();
 
         self.normalise()?;
@@ -143,27 +142,27 @@ where
                 self.x <<= 1;
             } else {
                 // self.low >= self.half()
-                self.low = 2 * (self.low - self.half());
-                self.high = 2 * (self.high - self.half());
-                self.x = 2 * (self.x - self.half());
+                self.low = (self.low - self.half()) << 1;
+                self.high = (self.high - self.half()) << 1;
+                self.x = (self.x - self.half()) << 1;
             }
 
             match self.input.next_bit()? {
                 Some(true) => {
-                    self.x += 1;
+                    self.x += M::B::ONE;
                 }
                 Some(false) | None => (),
             }
         }
 
-        while self.low >= self.quarter() && self.high < (3 * self.quarter()) {
-            self.low = 2 * (self.low - self.quarter());
-            self.high = 2 * (self.high - self.quarter());
-            self.x = 2 * (self.x - self.quarter());
+        while self.low >= self.quarter() && self.high < (self.three_quarter()) {
+            self.low = (self.low - self.quarter()) << 1;
+            self.high = (self.high - self.quarter()) << 1;
+            self.x = (self.x - self.quarter()) << 1;
 
             match self.input.next_bit()? {
                 Some(true) => {
-                    self.x += 1;
+                    self.x += M::B::ONE;
                 }
                 Some(false) | None => (),
             }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -75,7 +75,7 @@ where
         let precision = u32::BITS - frequency_bits;
 
         let low = 0;
-        let high = 2u32.pow(precision as u32);
+        let high = 1 << precision;
 
         let x = 0;
 
@@ -102,11 +102,11 @@ where
     }
 
     const fn half(&self) -> u32 {
-        2u32.pow(self.precision as u32 - 1)
+        1 << (self.precision - 1)
     }
 
     const fn quarter(&self) -> u32 {
-        2u32.pow(self.precision as u32 - 2)
+        1 << (self.precision - 2)
     }
 
     /// Read the next symbol from the stream of bits
@@ -136,9 +136,9 @@ where
     fn normalise(&mut self) -> io::Result<()> {
         while self.high < self.half() || self.low >= self.half() {
             if self.high < self.half() {
-                self.high *= 2;
-                self.low *= 2;
-                self.x *= 2;
+                self.high <<= 1;
+                self.low <<= 1;
+                self.x <<= 1;
             } else {
                 // self.low >= self.half()
                 self.low = 2 * (self.low - self.half());

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -27,7 +27,7 @@ impl<M> Encoder<M, u32>
 where
     M: Model,
 {
-    /// Construct a new [`Encoder`],using the default [`BitStore`] (`u32`).
+    /// Construct a new [`Encoder`], using the default [`BitStore`] (`u32`).
     ///
     /// The 'precision' of the encoder is maximised, based on the number of bits
     /// needed to represent the [`Model::denominator`]. 'precision' bits is
@@ -54,25 +54,26 @@ where
     B: BitStore,
     M: Model,
 {
-    /// Construct a new [`Encoder`]
+    /// Construct a new [`Encoder`] with a custom [`BitStore`].
     ///
     /// The 'precision' of the encoder is maximised, based on the number of bits
     /// needed to represent the [`Model::denominator`]. 'precision' bits is
-    /// equal to [`u32::BITS`] - [`Model::denominator`] bits.
+    /// equal to [`BitStore::BITS`] - [`Model::denominator`] bits.
     ///
     /// # Panics
     ///
     /// The calculation of the number of bits used for 'precision' is subject to
     /// the following constraints:
     ///
-    /// - The total available bits is [`u32::BITS`]
+    /// - The total available bits is [`BitStore::BITS`]
     /// - The precision must use at least 2 more bits than that needed to
     ///   represent [`Model::denominator`]
     ///
     /// If these constraints cannot be satisfied this method will panic in debug
     /// builds
     pub fn with_bitstore(model: M) -> Self {
-        let precision = util::precision(model.max_denominator());
+        let precision = util::precision::<B>(model.max_denominator());
+        dbg!(precision);
 
         let low = B::ZERO;
         let high = B::ONE << precision;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use bitstream_io::BitWrite;
 
-use crate::{Error, Model};
+use crate::{util, BitStore, Error, Model};
 
 // this algorithm is derived from this article - https://marknelson.us/posts/2014/10/19/data-compression-with-arithmetic-coding.html
 
@@ -11,19 +11,47 @@ use crate::{Error, Model};
 /// An arithmetic decoder converts a stream of symbols into a stream of bits,
 /// using a predictive [`Model`].
 #[derive(Debug)]
-pub struct Encoder<M>
+pub struct Encoder<M, B = u32>
 where
+    B: BitStore,
     M: Model,
 {
     model: M,
     precision: u32,
-    low: u32,
-    high: u32,
+    low: B,
+    high: B,
     pending: usize,
 }
 
-impl<M> Encoder<M>
+impl<M> Encoder<M, u32>
 where
+    M: Model,
+{
+    /// Construct a new [`Encoder`],using the default [`BitStore`] (`u32`).
+    ///
+    /// The 'precision' of the encoder is maximised, based on the number of bits
+    /// needed to represent the [`Model::denominator`]. 'precision' bits is
+    /// equal to [`u32::BITS`] - [`Model::denominator`] bits.
+    ///
+    /// # Panics
+    ///
+    /// The calculation of the number of bits used for 'precision' is subject to
+    /// the following constraints:
+    ///
+    /// - The total available bits is [`u32::BITS`]
+    /// - The precision must use at least 2 more bits than that needed to
+    ///   represent [`Model::denominator`]
+    ///
+    /// If these constraints cannot be satisfied this method will panic in debug
+    /// builds
+    pub fn new(model: M) -> Self {
+        Encoder::with_bitstore(model)
+    }
+}
+
+impl<M, B> Encoder<M, B>
+where
+    B: BitStore,
     M: Model,
 {
     /// Construct a new [`Encoder`]
@@ -43,17 +71,11 @@ where
     ///
     /// If these constraints cannot be satisfied this method will panic in debug
     /// builds
-    pub fn new(model: M) -> Self {
-        let frequency_bits = model.max_denominator().log2() + 1;
-        let minimum_precision = frequency_bits + 2;
-        debug_assert!(
-            (frequency_bits + minimum_precision) <= u32::BITS,
-            "not enough bits to guarantee overflow/underflow avoidance"
-        );
-        let precision = u32::BITS - frequency_bits;
+    pub fn with_bitstore(model: M) -> Self {
+        let precision = util::precision(model.max_denominator());
 
-        let low = 0;
-        let high = 2u32.pow(precision as u32);
+        let low = B::ZERO;
+        let high = B::ONE << precision;
         let pending = 0;
 
         Self {
@@ -65,12 +87,16 @@ where
         }
     }
 
-    const fn half(&self) -> u32 {
-        2u32.pow(self.precision as u32 - 1)
+    fn three_quarter(&self) -> B {
+        self.half() + self.quarter()
     }
 
-    const fn quarter(&self) -> u32 {
-        2u32.pow(self.precision as u32 - 2)
+    fn half(&self) -> B {
+        B::ONE << (self.precision - 1)
+    }
+
+    fn quarter(&self) -> B {
+        B::ONE << (self.precision - 2)
     }
 
     fn encode_symbol<W: BitWrite>(
@@ -78,11 +104,12 @@ where
         symbol: Option<&M::Symbol>,
         output: &mut W,
     ) -> Result<(), Error<M::ValueError>> {
-        let range = self.high - self.low + 1;
+        let range = self.high - self.low + B::ONE;
         let p = self.model.probability(symbol).map_err(Error::ValueError)?;
 
-        self.high = self.low + (range * p.end) / self.model.denominator() - 1;
-        self.low += (range * p.start) / self.model.denominator();
+        self.high =
+            self.low + (range * B::from(p.end)) / B::from(self.model.denominator()) - B::ONE;
+        self.low += (range * B::from(p.start)) / B::from(self.model.denominator());
         self.model.update(symbol);
         self.normalise(output)?;
         Ok(())
@@ -92,20 +119,20 @@ where
         while self.high < self.half() || self.low >= self.half() {
             if self.high < self.half() {
                 self.emit(false, output)?;
-                self.high *= 2;
-                self.low *= 2;
+                self.high <<= 1;
+                self.low <<= 1;
             } else {
                 // self.low >= self.half()
                 self.emit(true, output)?;
-                self.low = 2 * (self.low - self.half());
-                self.high = 2 * (self.high - self.half());
+                self.low = (self.low - self.half()) << 1;
+                self.high = (self.high - self.half()) << 1;
             }
         }
 
-        while self.low >= self.quarter() && self.high < (3 * self.quarter()) {
+        while self.low >= self.quarter() && self.high < (self.three_quarter()) {
             self.pending += 1;
-            self.low = 2 * (self.low - self.quarter());
-            self.high = 2 * (self.high - self.quarter());
+            self.low = (self.low - self.quarter()) << 1;
+            self.high = (self.high - self.quarter()) << 1;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@ pub use encoder::Encoder;
 mod decoder;
 pub use decoder::Decoder;
 
+mod bitstore;
+pub use bitstore::BitStore;
+
+mod util;
+
 /// Errors that can occur during encoding/decoding
 #[derive(Debug, thiserror::Error)]
 pub enum Error<E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs, clippy::all, missing_debug_implementations)]
 #![warn(clippy::pedantic)]
 #![feature(int_log)]
+#![feature(associated_type_defaults)]
 
 mod model;
 pub use model::Model;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,11 @@
-pub fn precision(max_denominator: u32) -> u32 {
+use crate::BitStore;
+
+pub fn precision<B: BitStore>(max_denominator: u32) -> u32 {
     let frequency_bits = max_denominator.log2() + 1;
     let minimum_precision = frequency_bits + 2;
     debug_assert!(
-        (frequency_bits + minimum_precision) <= u32::BITS,
+        (frequency_bits + minimum_precision) <= B::BITS,
         "not enough bits to guarantee overflow/underflow avoidance"
     );
-    u32::BITS - frequency_bits
+    B::BITS - frequency_bits
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use crate::BitStore;
 
-pub fn precision<B: BitStore>(max_denominator: u32) -> u32 {
+pub fn precision<B: BitStore>(max_denominator: B) -> u32 {
     let frequency_bits = max_denominator.log2() + 1;
     let minimum_precision = frequency_bits + 2;
     debug_assert!(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,9 @@
+pub fn precision(max_denominator: u32) -> u32 {
+    let frequency_bits = max_denominator.log2() + 1;
+    let minimum_precision = frequency_bits + 2;
+    debug_assert!(
+        (frequency_bits + minimum_precision) <= u32::BITS,
+        "not enough bits to guarantee overflow/underflow avoidance"
+    );
+    u32::BITS - frequency_bits
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,29 @@
+use arithmetic_coding::{BitStore, Decoder, Encoder, Model};
+use bitstream_io::{BigEndian, BitReader, BitWrite, BitWriter};
+
+pub fn round_trip<B, M>(input: Vec<M::Symbol>, model: M)
+where
+    B: BitStore,
+    M: Model + Clone,
+    M::Symbol: PartialEq + std::fmt::Debug + Clone,
+{
+    let mut bitwriter = BitWriter::endian(Vec::new(), BigEndian);
+
+    let mut encoder = Encoder::<M, B>::with_bitstore(model.clone());
+
+    encoder.encode(input.clone(), &mut bitwriter).unwrap();
+    bitwriter.byte_align().unwrap();
+
+    let buffer = bitwriter.into_writer();
+
+    let bitreader = BitReader::endian(buffer.as_slice(), BigEndian);
+    let mut decoder = Decoder::new(model, bitreader).unwrap();
+    let mut output = Vec::new();
+
+    while let Some(symbol) = decoder.decode_symbol().unwrap() {
+        output.push(symbol);
+    }
+
+    // assert_eq!(input, output);
+    panic!()
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,15 +1,14 @@
-use arithmetic_coding::{BitStore, Decoder, Encoder, Model};
+use arithmetic_coding::{Decoder, Encoder, Model};
 use bitstream_io::{BigEndian, BitReader, BitWrite, BitWriter};
 
-pub fn round_trip<B, M>(input: Vec<M::Symbol>, model: M)
+pub fn round_trip<M>(input: Vec<M::Symbol>, model: M)
 where
-    B: BitStore,
     M: Model + Clone,
     M::Symbol: PartialEq + std::fmt::Debug + Clone,
 {
     let mut bitwriter = BitWriter::endian(Vec::new(), BigEndian);
 
-    let mut encoder = Encoder::<M, B>::with_bitstore(model.clone());
+    let mut encoder = Encoder::<M>::new(model.clone());
 
     encoder.encode(input.clone(), &mut bitwriter).unwrap();
     bitwriter.byte_align().unwrap();
@@ -24,6 +23,5 @@ where
         output.push(symbol);
     }
 
-    // assert_eq!(input, output);
-    panic!()
+    assert_eq!(input, output);
 }

--- a/tests/sherlock.rs
+++ b/tests/sherlock.rs
@@ -18,7 +18,7 @@ impl Model for StringModel {
     type Symbol = char;
     type ValueError = Error;
 
-    fn probability(&self, symbol: Option<&Self::Symbol>) -> Result<Range<u32>, Error> {
+    fn probability(&self, symbol: Option<&Self::Symbol>) -> Result<Range<Self::B>, Error> {
         if let Some(char) = symbol {
             match ALPHABET.chars().position(|x| &x == char) {
                 Some(index) => Ok((index as u32)..(index as u32 + 1)),
@@ -30,11 +30,11 @@ impl Model for StringModel {
         }
     }
 
-    fn symbol(&self, value: u32) -> Option<Self::Symbol> {
+    fn symbol(&self, value: Self::B) -> Option<Self::Symbol> {
         ALPHABET.chars().nth(value as usize)
     }
 
-    fn max_denominator(&self) -> u32 {
+    fn max_denominator(&self) -> Self::B {
         ALPHABET.len() as u32 + 1
     }
 }
@@ -46,25 +46,5 @@ fn round_trip_u32() {
     file.read_to_string(&mut string).unwrap();
     let input = string.chars().collect();
 
-    common::round_trip::<u32, _>(input, StringModel);
-}
-
-#[test]
-fn round_trip_u64() {
-    let mut file = File::open("./resources/sherlock.txt").unwrap();
-    let mut string = String::new();
-    file.read_to_string(&mut string).unwrap();
-    let input = string.chars().collect();
-
-    common::round_trip::<u64, _>(input, StringModel);
-}
-
-#[test]
-fn round_trip_u128() {
-    let mut file = File::open("./resources/sherlock.txt").unwrap();
-    let mut string = String::new();
-    file.read_to_string(&mut string).unwrap();
-    let input = string.chars().collect();
-
-    common::round_trip::<u128, _>(input, StringModel);
+    common::round_trip(input, StringModel);
 }


### PR DESCRIPTION
allows the `Model` to determine an appropriate type to store the bits of precision within the encoder/decoder