### PR TITLE
feat!: make 'flush' method on encoder consume 'self'

### DIFF
--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -22,7 +22,7 @@ where
     I: IntoIterator<Item = M::Symbol>,
 {
     let mut bitwriter = BitWriter::endian(Vec::new(), BigEndian);
-    let mut encoder = Encoder::new(model, &mut bitwriter);
+    let encoder = Encoder::new(model, &mut bitwriter);
 
     encoder.encode_all(input).unwrap();
     bitwriter.byte_align().unwrap();

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -26,7 +26,7 @@ where
     I: IntoIterator<Item = M::Symbol>,
 {
     let mut bitwriter = BitWriter::endian(Vec::new(), BigEndian);
-    let mut encoder = Encoder::new(model, &mut bitwriter);
+    let encoder = Encoder::new(model, &mut bitwriter);
 
     encoder.encode_all(input).unwrap();
     bitwriter.byte_align().unwrap();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -92,7 +92,7 @@ where
     /// This method can fail if the underlying [`BitWrite`] cannot be written
     /// to.
     pub fn encode_all(
-        &mut self,
+        mut self,
         symbols: impl IntoIterator<Item = M::Symbol>,
     ) -> Result<(), Error<M::ValueError>> {
         for symbol in symbols {
@@ -138,7 +138,7 @@ where
     ///
     /// This method can fail if the underlying [`BitWrite`] cannot be written
     /// to.
-    pub fn flush(&mut self) -> io::Result<()> {
+    pub fn flush(self) -> io::Result<()> {
         self.state.flush()
     }
 
@@ -236,7 +236,7 @@ where
     /// # Errors
     ///
     /// This method can fail if the output cannot be written to
-    pub fn flush(&mut self) -> io::Result<()> {
+    pub fn flush(mut self) -> io::Result<()> {
         self.pending += 1;
         if self.state.low <= self.state.quarter() {
             self.emit(false)?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,7 +17,7 @@ where
     M: Model,
 {
     let mut bitwriter = BitWriter::endian(Vec::new(), BigEndian);
-    let mut encoder = Encoder::new(model, &mut bitwriter);
+    let encoder = Encoder::new(model, &mut bitwriter);
 
     encoder.encode_all(input).unwrap();
     bitwriter.byte_align().unwrap();


### PR DESCRIPTION
closes #77

there is one downside to this approach i can immediately see, but it's a bit niche- a user cannot retry a write to an output buffer if writing fails during a call to 'flush'.